### PR TITLE
This commit ensures that videos played in the portfolio modal are mut…

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
 
     <div id="video-modal" class="fixed inset-0 bg-black/80 z-50 hidden items-center justify-center p-4 backdrop-blur-sm">
         <div class="bg-gray-900/50 border border-white/10 rounded-lg shadow-xl relative w-full max-w-4xl">
-            <video id="modal-video-player" class="w-full h-auto rounded-t-lg" controls autoplay playsinline></video>
+            <video id="modal-video-player" class="w-full h-auto rounded-t-lg" controls autoplay playsinline muted></video>
             <div id="video-selector-container" class="flex justify-center p-2 bg-black/20 rounded-b-lg"></div>
             <button id="close-modal-btn" class="absolute -top-4 -right-4 text-white bg-slate-800 border border-white/20 rounded-full p-1.5 hover:bg-slate-700 transition-colors">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/js/ui.js
+++ b/js/ui.js
@@ -209,6 +209,7 @@ function setupEventListeners() {
                 }
 
                 if (singleVideoSrc || multipleVideoSrcs) {
+                    modalVideoPlayer.muted = true;
                     videoModal.classList.remove('hidden');
                     videoModal.classList.add('flex');
                 }


### PR DESCRIPTION
…ed by default.

The following changes were made:
- Added the `muted` attribute to the `<video>` element with the ID `modal-video-player` in `index.html`.
- Programmatically set `modalVideoPlayer.muted = true;` in `js/ui.js` when the video modal is opened to ensure cross-browser consistency.